### PR TITLE
feat: text field 支持渲染Vnode

### DIFF
--- a/src/ams/mixins/field-view-mixin.js
+++ b/src/ams/mixins/field-view-mixin.js
@@ -4,7 +4,10 @@ export default {
     computed: {
         on,
         viewValue() {
-            return this.field.view ? this.field.view(this.value, this.field, this.context) : this.value;
+            return this.field.view ? this.field.view(this.value, this.field, this.context, this.$createElement) : this.value;
+        },
+        htmlViewValue() {
+            return this.field.htmlView && this.field.htmlView(this.value, this.field, this.context, this.$createElement);
         }
     },
     inject: ['$block'],

--- a/src/fields/common/text-view.vue
+++ b/src/fields/common/text-view.vue
@@ -1,5 +1,40 @@
+<!--
+  以 fields: {
+    'status': {
+      'type': 'text',
+      'label': 'status',
+      view(fieldValue, field) {
+      return fieldValue > 0 ? `+${fieldValue}` : `-${fieldValue}`
+      },
+    },
+  }
+  为例：
+
+  `ams-field-${field.type}-${field.ctx}` === 'ams-field-text-view'
+
+  其中
+  field === {
+    "name": "status",
+    "ctx": "view",
+    "props": {
+      "clearable": true
+    },
+    "on": {},
+    "type": "text",
+    "label": "status",
+    "default": ""
+  }
+
+  value ==== 2
+  name(blockName) === 'dspListView'
+  path(第一行) === list[0].status
+ -->
+
 <template>
-    <div :style="field.style" v-bind="field.props" v-on="on">{{ actualViewText }}<el-popover v-if="showMoreIcon"
+    <div :style="field.style" v-bind="field.props" v-on="on">
+        <vnode :vnode="htmlViewValue" v-if="htmlViewValue"/>
+        <template v-else>{{ actualViewText}}</template>
+        <el-popover v-if="showMoreIcon"
                     :placement="field.collapsePlacement || 'right'"
                     :title="field.collapseTitle || ''"
                     :width="field.collapseWidth || 200"
@@ -19,6 +54,12 @@
 import mixins from '../../ams/mixins';
 
 export default {
+    components: {
+        Vnode: {
+            functional: true,
+            render: (h, ctx) => ctx.props.vnode
+        }
+    },
     mixins: [mixins.fieldViewMixin],
     data() {
         return {


### PR DESCRIPTION
```
fields: {
  rate: {
     type: 'text',
     htmlView(value, field, row, h) {
        return h('span', value)
     }
  }

}
```