### PR TITLE
feat: add viewItemDialog/viewItemDrawer

### DIFF
--- a/src/ams/mixins/operation-mixin.js
+++ b/src/ams/mixins/operation-mixin.js
@@ -46,7 +46,7 @@ export default {
                 this.$message('已选择的数据项为空');
                 return;
             }
-            this.$block.emitEvent(this.operation.event || this.operationKey, this.operation);
+            this.$block.emitEvent(this.operation.event || this.operationKey, { operation: this.operation });
         }
     },
 


### PR DESCRIPTION
### 新增 viewItemDialog/viewItemDrawer

1.  const FROM_BLOCK_NAME = `${WRAP_BLOCK_NAME}From`; Form 单词拼写错误
2. 新增 viewItemDialog/viewItemDrawer 用于查看表格RowItem
3. 因为查看模式不需要编辑，因此也需要修改 form 的 ctx 模式为：`view`

```js
operations: {
  viewItemDialog: {
    type: 'button',
    label: '查看更多数据'
  }
}
```

### 同时修复了一个覆盖风险

`this.$block.emitEvent(this.operation.event || this.operationKey, this.operation);`
变更为
`this.$block.emitEvent(this.operation.event || this.operationKey, { operation: this.operation });`

原因：
在某个场景下，比如：
```js
operations: {
  addItemDialog: {
    type: 'button',
    label: '编辑'
  }
}
```

如果按照 

`this.$block.emitEvent(this.operation.event || this.operationKey, this.operation);`

->  `ams.callAction('addItemDialog',  this.operation //params)`

-> 

```js
ams.callAction('addItemDialog',  this.operation //params)

// 即调用item.js 的
export async function addItemDialog(params) {
    await commonHandlerItem.call(this, { type: 'add', insertType: 'dialog', ...params });
}

```

这样会导致 `...params`(即 ...this.operation)，`this.operation.type`也就是 会覆盖 `type: 'add'`，这样会导致 type为button，addItemDialog 的时候，按钮按照 `label: type === 'add' ? '添加' : '修改',`的逻辑，总是显示为：`修改`，而非`添加`

因此将 operation 作为一个对象进行传递，然后从中再获取具体的 fields、formProps、dialogProps 等配置，修正覆盖风险